### PR TITLE
Add "stcgal_protocol" field

### DIFF
--- a/boards/stc15f204ea.json
+++ b/boards/stc15f204ea.json
@@ -13,6 +13,7 @@
     "maximum_ram_size": 256,
     "maximum_size": 4096,
     "protocol": "stcgal",
+    "stcgal_protocol": "stc15",
     "protocols": [
       "stcgal"
     ]

--- a/boards/stc15w204s.json
+++ b/boards/stc15w204s.json
@@ -13,6 +13,7 @@
     "maximum_ram_size": 256,
     "maximum_size": 4096,
     "protocol": "stcgal",
+    "stcgal_protocol": "stc15",
     "protocols": [
       "stcgal"
     ]

--- a/boards/stc15w404as.json
+++ b/boards/stc15w404as.json
@@ -13,6 +13,7 @@
     "maximum_ram_size": 512,
     "maximum_size": 4096,
     "protocol": "stcgal",
+    "stcgal_protocol": "stc15",
     "protocols": [
       "stcgal"
     ]

--- a/boards/stc15w408as.json
+++ b/boards/stc15w408as.json
@@ -13,6 +13,7 @@
     "maximum_ram_size": 512,
     "maximum_size": 8192,
     "protocol": "stcgal",
+    "stcgal_protocol": "stc15",
     "protocols": [
       "stcgal"
     ]

--- a/builder/main.py
+++ b/builder/main.py
@@ -144,9 +144,11 @@ upload_actions = []
 
 if upload_protocol == "stcgal":
     f_cpu_khz = int(board_config.get("build.f_cpu")) / 1000
+    stcgal_protocol = board_config.get("upload.stcgal_protocol")
     stcgal = join(env.PioPlatform().get_package_dir("tool-stcgal") or "", "stcgal.py")
     env.Replace(
         UPLOADERFLAGS=[
+            "-P", stcgal_protocol,
             "-p", "$UPLOAD_PORT",
             "-t", int(f_cpu_khz),
             "-a"


### PR DESCRIPTION
Add "stcgal_protocol" field in boards/stcxxxxxx.json and use this field in  builder/main.py for using stcgal to upload firmware onto STC MCUs in the right way. If we don't explicitly specify which protocol stcgal will use with flag "-P", we'll get stuck in "Cycling power", because stcgal does not always select the correct protocol by autodetection.

The mapping between protocols and MCU series in stcgal is shown at:
https://github.com/grigorig/stcgal/blob/master/doc/USAGE.md#protocols

Compatibly, users can override default Generic STCxxxxxx stcgal upload_protocol using board_upload.stcgal_protocol option. For example, board_upload.stcgal_protocol = "stc12", board_upload.stcgal_protocol = "stc8", etc.