### PR TITLE
Add dual DPTR support for STC

### DIFF
--- a/boards/stc15f204ea.json
+++ b/boards/stc15f204ea.json
@@ -6,7 +6,7 @@
     "size_code": 4096,
     "size_heap": 64,
     "mcu": "stc15f204ea",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {

--- a/boards/stc15f2k60s2.json
+++ b/boards/stc15f2k60s2.json
@@ -6,7 +6,7 @@
     "size_code": 61440,
     "size_heap": 128,
     "mcu": "stc15f2k60s2",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {

--- a/boards/stc15w204s.json
+++ b/boards/stc15w204s.json
@@ -6,7 +6,7 @@
     "size_code": 4096,
     "size_heap": 64,
     "mcu": "stc15w204s",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {

--- a/boards/stc15w404as.json
+++ b/boards/stc15w404as.json
@@ -6,7 +6,7 @@
     "size_code": 4096,
     "size_heap": 128,
     "mcu": "stc15w404as",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {

--- a/boards/stc15w408as.json
+++ b/boards/stc15w408as.json
@@ -6,7 +6,7 @@
     "size_code": 8192,
     "size_heap": 128,
     "mcu": "stc15w408as",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {

--- a/boards/stc89c52rc.json
+++ b/boards/stc89c52rc.json
@@ -6,7 +6,7 @@
     "size_code": 8192,
     "size_heap": 128,
     "mcu": "stc89c52rc",
-    "cpu": "mcs51"
+    "cpu": "p89c51r"
   },
   "frameworks": [],
   "upload": {


### PR DESCRIPTION
STC15 series have dual DPTR, controlled via DPS at 0xA2.0.here's the [document](http://www.stcmcudata.com/datasheet/stc/STC-AD-PDF/STC15-English.pdf)

P297 3.3.3 Dual Data Pointer Register(DPTR)

SDCC supports it.，p89c51r

https://sourceforge.net/p/sdcc/wiki/8051%20Variants/