### PR TITLE
Add initial support for CH559 (WIP/RFC)

### DIFF
--- a/boards/ch559.json
+++ b/boards/ch559.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "f_cpu": "56000000L",
+    "size_iram": 256,
+    "size_xram": 6144,
+    "size_code": 65536,
+    "size_heap": 128,
+    "mcu": "ch559",
+    "cpu": "mcs51"
+  },
+  "frameworks": [],
+  "upload": {
+    "maximum_ram_size": 6400,
+    "maximum_size": 65536,
+    "protocol": "ch55x"
+  },
+  "name": "CH559",
+  "url": "http://www.wch-ic.com/products/CH559.html",
+  "vendor": "WCH"
+}

--- a/boards/ch559.json
+++ b/boards/ch559.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "f_cpu": "56000000L",
+    "f_cpu": "12000000L",
     "size_iram": 256,
     "size_xram": 6144,
     "size_code": 65536,

--- a/builder/main.py
+++ b/builder/main.py
@@ -163,11 +163,13 @@ if upload_protocol == "stcgal":
 
 # CH55x upload tool
 elif upload_protocol == "ch55x":
-    UPLOADER="ch55xtool.py"
-    UPLOADERFLAGS=[
-        "-r","-f"
-    ];
-    UPLOADCMD="python3 $UPLOADER $UPLOADERFLAGS $BUILD_DIR/${PROGNAME}.bin"
+    env.Replace(
+        UPLOADER="ch55xtool.py",
+        UPLOADERFLAGS=[
+            "-f"
+        ],
+        UPLOADCMD="python3 $UPLOADER $UPLOADERFLAGS $BUILD_DIR/${PROGNAME}.bin")
+
     upload_actions = [
         env.VerboseAction(" ".join(["$OBJCOPY","-I","ihex","-O","binary",
             "$SOURCE", "$BUILD_DIR/${PROGNAME}.bin"]), "Creating binary"),

--- a/builder/main.py
+++ b/builder/main.py
@@ -168,7 +168,7 @@ elif upload_protocol == "ch55x":
         UPLOADERFLAGS=[
             "-f"
         ],
-        UPLOADCMD="python3 $UPLOADER $UPLOADERFLAGS $BUILD_DIR/${PROGNAME}.bin")
+        UPLOADCMD="$PYTHONEXE $UPLOADER $UPLOADERFLAGS $BUILD_DIR/${PROGNAME}.bin")
 
     upload_actions = [
         env.VerboseAction(" ".join(["$OBJCOPY","-I","ihex","-O","binary",

--- a/builder/main.py
+++ b/builder/main.py
@@ -161,6 +161,19 @@ if upload_protocol == "stcgal":
         env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")
     ]
 
+# CH55x upload tool
+elif upload_protocol == "ch55x":
+    UPLOADER="ch55xtool.py"
+    UPLOADERFLAGS=[
+        "-r","-f"
+    ];
+    UPLOADCMD="python3 $UPLOADER $UPLOADERFLAGS $BUILD_DIR/${PROGNAME}.bin"
+    upload_actions = [
+        env.VerboseAction(" ".join(["$OBJCOPY","-I","ihex","-O","binary",
+            "$SOURCE", "$BUILD_DIR/${PROGNAME}.bin"]), "Creating binary"),
+        env.VerboseAction("$UPLOADCMD", "Uploading ${PROGNAME}.bin")
+    ]
+
 # custom upload tool
 elif upload_protocol == "custom":
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]


### PR DESCRIPTION
The CH559 is a USB microcontroller based on the MCS-51 architecture.

This chip requires a custom upload protocol, I have placed the framework for that in main.py, I am not clear on how to have platformIO grab the necessary python upload tool automagically from here: https://github.com/MarsTechHAN/ch552tool

   This tool depends on libusb as well.

Once these details are figured out/solved I can follow with board definitions for the remainder of the CH55x family.