### PR TITLE
Customizable upload baud rate support for stcgal.

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -150,6 +150,8 @@ if upload_protocol == "stcgal":
             stcgal_protocol,
             "-p",
             "$UPLOAD_PORT",
+            "-b",
+            "$UPLOAD_SPEED",
             "-t",
             int(f_cpu_khz),
             "-a",


### PR DESCRIPTION
Customizable upload baud rate support for stcgal.

So users can use "upload_speed = 38400" in platformio.ini to prevent download errors on STC MCUs that are using software UART that can't operate at high baud rates (like STC15F10X)