### PR TITLE
Add CH552 board

### DIFF
--- a/boards/CH552.json
+++ b/boards/CH552.json
@@ -5,7 +5,7 @@
         "size_xram": 1024,
         "size_code": 14336,
         "size_heap": 128,
-        "mcu": "ch552t",
+        "mcu": "ch552",
         "cpu": "mcs51"
     },
     "frameworks": [],

--- a/boards/CH552.json
+++ b/boards/CH552.json
@@ -1,0 +1,20 @@
+{
+    "build": {
+        "f_cpu": "24000000",
+        "size_iram": 256,
+        "size_xram": 1024,
+        "size_code": 14336,
+        "size_heap": 128,
+        "mcu": "ch552t",
+        "cpu": "mcs51"
+    },
+    "frameworks": [],
+    "upload": {
+        "maximum_ram_size": 1280,
+        "maximum_size": 14336,
+        "protocol": "ch55x"
+    },
+    "name": "Generic CH552",
+    "url": "https://www.wch.cn/downloads/CH552DS1_PDF.html",
+    "vendor": "WCH"
+}


### PR DESCRIPTION
Adds the definition for the CH552 board, e.g. https://github.com/WeActStudio/WeActStudio.CH552CoreBoard